### PR TITLE
Add grants section similar to projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,8 @@ links:
     url: /talks
   - title: Projects
     url: /projects
+  - title: Grants
+    url: /grants
   - title: Software
     url: /software
   - title: Industry

--- a/_layouts/grants.html
+++ b/_layouts/grants.html
@@ -1,0 +1,32 @@
+{% include head-dark.html %}
+
+    <div id='bump'>
+        <!-- <section class="article archive"> -->
+          <article class="archive-wrap">
+              <ol class="post-list">
+                  <!--<lh style="text-align: center"><h2><span class="bb"><a href="{{ page.url }}">{{ page.title }}</a></span></h2></lh>-->
+                  {% for post in site.categories.grants %}
+                  <li>
+                    <table>
+                    <tr><td>
+                     <a href="{{ site.url }}{{ post.url }}">
+                     <div class="featured-image-project" style="background-image: url({{ site.url }}/images/{{ post.image.thumb }})">
+                     </div>
+                     </a>
+                     </td><td>
+                     <div class="deets left-slide" itemscope itemtype="http://schema.org/BlogPosting" itemprop="blogPost">
+                     <h1>{% if post.external_url %} <a href="{{ post.external_url }}" onclick="_gaq.push(['_trackpageview', '{{ post.url }}']);" >{{ post.title }}</a> {% else %}<a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a>{% endif %}</h1>
+                     <!-- {% if post.modified %}<p class="date"><span class="date"><time datetime="{{ page.modified }}" itemprop="dateModified">Updated on {{ post.modified | date: "%B %d, %Y" }}</time></span>{% else %}<p class="date"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%B %d, %Y" }}</time>{% endif %}</p> -->
+                     <p class="date"><span class="date"><time datetime="{{ post.role }}" itemprop="dateModified">{{ post.role }}</time></span></p>
+                     <!-- <p class="summary">{% if post.description %}{{ post.description  | strip_html | strip_newlines | truncate: 120 }}{% else %}{{ post.content | strip_html | strip_newlines | truncate: 120 }}{% endif %}</p> -->
+                     <p class="summary">{% if post.description %}{{ post.description  | strip_html | strip_newlines | truncate: 120 }}{% else %}{{ post.content }}{% endif %}</p>
+                     </div>
+                     </td></tr></table>
+                  </li>
+                  {% endfor %}
+              </ol>
+          </article>
+        <!-- </section> -->
+    </div>
+
+{% include footer.html %}

--- a/_posts/grants/2020-06-01-Explainable-Probabilistic-ML.md
+++ b/_posts/grants/2020-06-01-Explainable-Probabilistic-ML.md
@@ -1,0 +1,13 @@
+---
+layout: external
+title: Explainable Probabilistic Machine Learning
+role: 2020–2023 Spanish Ministry of Science and Innovation - Principal Investigator
+category: grants
+external_url: https://www.ciencia.gob.es/stfls/MICINN/Ministerio/FICHEROS/PRP_PID_2019.pdf
+tags: [explainable AI, probabilistic modeling]
+image:
+  thumb: bayesNet.png
+published: true
+---
+
+National research grant supporting the development of explainable machine learning methods grounded in probabilistic modeling. The project funds methodological advances and software prototypes that help practitioners interpret predictions while retaining rigorous uncertainty quantification.

--- a/_posts/grants/2026-01-01-DK-Future-Energy.md
+++ b/_posts/grants/2026-01-01-DK-Future-Energy.md
@@ -1,0 +1,13 @@
+---
+layout: external
+title: DK-Future: Data-Driven Energy Futures
+role: 2026–2029 Aalborg University - Co-Investigator
+category: grants
+external_url:
+tags: [energy systems, trustworthy AI]
+image:
+  thumb: 2025-AIEcoNet.png
+published: true
+---
+
+Interdisciplinary grant that applies trustworthy machine learning to energy systems planning and operation. The work combines probabilistic forecasting and decision-support tools to accelerate Denmark's transition toward sustainable power grids.

--- a/grants.md
+++ b/grants.md
@@ -1,0 +1,6 @@
+---
+layout: grants
+permalink: /grants/index.html
+title: "Grants"
+tags: [andres r. masegosa, grants, funding]
+---


### PR DESCRIPTION
## Summary
- add a new Grants section to site navigation with dedicated page
- create a grants layout mirroring the projects listing
- add initial grant entries for explainable ML funding and DK-Future energy work

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920197cac3c8333b5e61014b6c6a345)