### PR TITLE
Widen short CV layout

### DIFF
--- a/_includes/head-dark.html
+++ b/_includes/head-dark.html
@@ -78,7 +78,7 @@
 <link rel="shortcut icon" href="{{ site.url }}/favicon.png">
 
 <div id="bump">
-  <body class="">
+  <body class="{{ page.body_class | default: '' }}">
     <header class="site-header darken">
       <div class="wrap">
         <hgroup>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -50,7 +50,7 @@
 <link rel="shortcut icon" href="{{ site.url }}/favicon.ico">
 
 <div id="bump">
-  <body class="">
+  <body class="{{ page.body_class | default: '' }}">
     <header class="site-header">
       <div class="wrap">
         <hgroup>

--- a/assets/css/i.css
+++ b/assets/css/i.css
@@ -370,6 +370,13 @@ input {
   margin: 0 auto;
   float: none; }
 
+body.short-cv .wrap.post {
+  max-width: 1100px; }
+
+body.short-cv .post {
+  max-width: 1100px;
+  width: 90%; }
+
 /* Header */
 header.site-header {
   padding: 40px 0;

--- a/assets/sass/_styles.scss
+++ b/assets/sass/_styles.scss
@@ -201,6 +201,15 @@ input {
     float: none;
 }
 
+body.short-cv .wrap.post {
+    max-width: 1100px;
+}
+
+body.short-cv .post {
+    max-width: 1100px;
+    width: 90%;
+}
+
 
 /* Header */
 

--- a/bio.md
+++ b/bio.md
@@ -6,6 +6,7 @@ description:
 tags: [andres r. masegosa, andres, machine learning, Aalborg, Copenhagen, Denmark]
 image:
   feature: granadapartal.jpg
+body_class: short-cv
 ---
 
 "Chaos is merely order waiting to be deciphered."


### PR DESCRIPTION
## Summary
- allow pages to supply a custom body class
- widen the Short-CV page layout to reduce unnecessary line breaks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201d21b51c8333a26bd4f7da597b31)