### PR TITLE
Add students section and example entry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,8 @@ links:
     url: /talks
   - title: Projects
     url: /projects
+  - title: Students
+    url: /students
   - title: Grants
     url: /grants
   - title: Software

--- a/_layouts/students.html
+++ b/_layouts/students.html
@@ -1,0 +1,32 @@
+{% include head-dark.html %}
+
+    <div id='bump'>
+        <!-- <section class="article archive"> -->
+          <article class="archive-wrap">
+              <ol class="post-list">
+                  <!--<lh style="text-align: center"><h2><span class="bb"><a href="{{ page.url }}">{{ page.title }}</a></span></h2></lh>-->
+                  {% for post in site.categories.students %}
+                  <li>
+                    <table>
+                    <tr><td>
+                     <a href="{{ site.url }}{{ post.url }}">
+                     <div class="featured-image-project" style="background-image: url({{ site.url }}/images/{{ post.image.thumb }})">
+                     </div>
+                     </a>
+                     </td><td>
+                     <div class="deets left-slide" itemscope itemtype="http://schema.org/BlogPosting" itemprop="blogPost">
+                     <h1>{% if post.external_url %} <a href="{{ post.external_url }}" onclick="_gaq.push(['_trackpageview', '{{ post.url }}']);" >{{ post.title }}</a> {% else %}<a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a>{% endif %}</h1>
+                     <!-- {% if post.modified %}<p class="date"><span class="date"><time datetime="{{ page.modified }}" itemprop="dateModified">Updated on {{ post.modified | date: "%B %d, %Y" }}</time></span>{% else %}<p class="date"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%B %d, %Y" }}</time>{% endif %}</p> -->
+                     <p class="date"><span class="date"><time datetime="{{ post.role }}" itemprop="dateModified">{{ post.role }}</time></span></p>
+                     <!-- <p class="summary">{% if post.description %}{{ post.description  | strip_html | strip_newlines | truncate: 120 }}{% else %}{{ post.content | strip_html | strip_newlines | truncate: 120 }}{% endif %}</p> -->
+                     <p class="summary">{% if post.description %}{{ post.description  | strip_html | strip_newlines | truncate: 120 }}{% else %}{{ post.content }}{% endif %}</p>
+                     </div>
+                     </td></tr></table>
+                  </li>
+                  {% endfor %}
+              </ol>
+          </article>
+        <!-- </section> -->
+    </div>
+
+{% include footer.html %}

--- a/_posts/students/2024-01-01-example-student.md
+++ b/_posts/students/2024-01-01-example-student.md
@@ -1,0 +1,13 @@
+---
+layout: external
+title: Jane Doe – PhD Candidate
+role: 2023–present — PhD student (co-supervised)
+category: students
+external_url: https://www.cs.aau.dk/
+tags: [students, supervision, probabilistic machine learning]
+image:
+  thumb: andresrm-circle.png
+published: true
+---
+
+Jane focuses on probabilistic machine learning for scientific discovery, collaborating with industry and academic partners on applied Bayesian modelling projects.

--- a/students.md
+++ b/students.md
@@ -1,0 +1,6 @@
+---
+layout: students
+permalink: /students/index.html
+title: "Students"
+tags: [andres r. masegosa, students, machine learning]
+---


### PR DESCRIPTION
## Summary
- add a dedicated students page and layout mirroring the existing project-style listings
- expose the students section in the main navigation
- seed the students section with an example PhD candidate entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692033ebe74883339cb46a2add170e2e)