### PR TITLE
Improve home page portrait styling

### DIFF
--- a/_layouts/home_page.html
+++ b/_layouts/home_page.html
@@ -7,33 +7,37 @@
           <article class="archive-wrap">
             <!-- <img id="jathumb" src="images/jathumb.jpg"/> -->
             <!-- <figure><img src="/images/jathumb.jpg" /></figure> -->
-            <figure><center><img src="images/andresrm-circle.png" style="width: 250px;float: left;margin-right: 30px;margin-top: 10px;"/></center></figure>
-            <br>
-            <br>
-            <p class="intro"> I am an associate profesor at the 
-            <a href="https://www.cs.aau.dk/">Department of Computer Science at Aalborg University</a> (Copenhagen Campus - Denmark). 
-            I have broad interests in probabilistic machine learning.</p>
-            
-            <p class="lead">
-            arma@cs.aau.dk
-            
-            <a href="https://scholar.google.com/citations?user=J1zoY7AAAAAJ&hl=en" class="icon">
-              <i class="ai ai-google-scholar-square ai-1x"></i>
-            </a>
-            
-            <a href="https://es.linkedin.com/in/andresmasegosa" class="icon">
-              <i class="fa fa-linkedin-square"></i>
-            </a>
-        	
-            <a href="https://github.com/andresmasegosa" class="icon">
-              <i class="fa fa-github fa-lg"></i>
-            </a>
+            <div class="home-hero">
+              <figure class="home-hero__photo">
+                <img src="images/andresrm-circle.png" alt="Portrait of Andres R. Masegosa" class="home-hero__img" />
+              </figure>
+              <div class="home-hero__content">
+                <p class="intro"> I am an associate profesor at the
+                <a href="https://www.cs.aau.dk/">Department of Computer Science at Aalborg University</a> (Copenhagen Campus - Denmark).
+                I have broad interests in probabilistic machine learning.</p>
 
-        	<a href="https://twitter.com/andresmasegosa" class="icon">
-              <i class="fa fa-twitter fa-lg"></i>
-            </a>
-            
-            </p>
+                <p class="lead">
+                arma@cs.aau.dk
+
+                <a href="https://scholar.google.com/citations?user=J1zoY7AAAAAJ&hl=en" class="icon">
+                  <i class="ai ai-google-scholar-square ai-1x"></i>
+                </a>
+
+                <a href="https://es.linkedin.com/in/andresmasegosa" class="icon">
+                  <i class="fa fa-linkedin-square"></i>
+                </a>
+
+                <a href="https://github.com/andresmasegosa" class="icon">
+                  <i class="fa fa-github fa-lg"></i>
+                </a>
+
+                    <a href="https://twitter.com/andresmasegosa" class="icon">
+                  <i class="fa fa-twitter fa-lg"></i>
+                </a>
+
+                </p>
+              </div>
+            </div>
 <!--             <br>
             <br>
               <ol class="post-list">

--- a/assets/css/i.css
+++ b/assets/css/i.css
@@ -527,6 +527,49 @@ header.site-header nav ul li a:hover {
 .article header .intro {
   text-align: left; }
 
+.home-hero {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-flow: row wrap;
+          flex-flow: row wrap;
+  gap: 32px;
+  margin-bottom: 32px; }
+
+.home-hero__photo {
+  margin: 0;
+  width: 250px;
+  max-width: 60vw;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #f9f9f9;
+  -webkit-box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+          box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 250px;
+          flex: 0 0 250px; }
+
+.home-hero__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  -o-object-fit: cover;
+     object-fit: cover; }
+
+.home-hero__content {
+  -webkit-box-flex: 1;
+      -ms-flex: 1 1 260px;
+          flex: 1 1 260px; }
+
 .archive {
   display: inline;
   float: left;


### PR DESCRIPTION
## Summary
- restyle the home page hero layout to wrap the portrait and intro content together
- apply circular cropping and subtle shadow to the portrait for a cleaner background blend
- keep contact and social links aligned beside the updated photo styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69296e82fac4833394c93329ac49bcdc)