### PR TITLE
Add Nature Communications to reviewer list in short-CV

### DIFF
--- a/bio.md
+++ b/bio.md
@@ -109,7 +109,7 @@ Trustworthy Machine Learning – Bayesian Methods – Uncertainty Quantification
 - **Area Coordinator**: NeurIPS, ICML, AISTATS.  
 - **Area Editor**: ACM Transactions on Probabilistic Machine Learning, Intelligent Data Analysis (IDA), Transactions on Machine Learning Research.  
 - **Program Committee**: NeurIPS, ICML, ICLR, AISTATS.  
-- **Reviewer**: JMLR, JAIR, Knowledge-Based Systems, IJAR, and others.
+- **Reviewer**: Nature Communications, JMLR, JAIR, Knowledge-Based Systems, IJAR, and others.
 
 ---
 
@@ -144,4 +144,3 @@ Trustworthy Machine Learning – Bayesian Methods – Uncertainty Quantification
 - 2005–2009 – **PhD in Computer Science**. University of Granada (Spain).  
 - 2003–2005 – **Master in Soft Computing and Artificial Intelligence**. University of Granada (Spain).  
 - 1998–2003 – **BSc Computer Engineering**. University of Granada (Spain).
-


### PR DESCRIPTION
### Motivation

- Reflect the new reviewer role by adding `Nature Communications` to the reviewer list in the `short-cv` section.
- Keep the public academic biography up-to-date across the site.

### Description

- Edited `bio.md` to add `Nature Communications` at the start of the `Reviewer` line in the editorial/roles section.
- This is a single-line content update within the short-CV portion of the biography page.

### Testing

- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b57a0284c8333b1de6fb36adbeae8)